### PR TITLE
fix wrong javascript quotes of aui:dialog

### DIFF
--- a/alloy/src/main/java/com/liferay/faces/alloy/renderkit/DialogRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/renderkit/DialogRenderer.java
@@ -115,16 +115,22 @@ public class DialogRenderer extends Renderer {
 	protected void writeBooleanAttribute(ResponseWriter responseWriter, Map<String, Object> attributes, String name,
 		boolean defaultValue, boolean lastAttribute) throws IOException {
 		String value = Boolean.toString(GetterUtil.getBoolean(attributes.get(name), defaultValue));
-		writeStringAttribute(responseWriter, name, value, lastAttribute);
+		writeStringAttribute(responseWriter, name, value, lastAttribute, false);
 	}
 
-	protected void writeStringAttribute(ResponseWriter responseWriter, String name, String value, boolean lastAttribute)
+	protected void writeStringAttribute(ResponseWriter responseWriter, String name, String value, boolean lastAttribute, boolean quote)
 		throws IOException {
 
 		if (value != null) {
 			responseWriter.write(name);
 			responseWriter.write(" : ");
+			if (quote) {
+				responseWriter.write("\"");
+			}
 			responseWriter.write(value);
+			if (quote) {
+				responseWriter.write("\"");
+			}
 
 			if (!lastAttribute) {
 				responseWriter.write(StringConstants.CHAR_COMMA);
@@ -135,7 +141,7 @@ public class DialogRenderer extends Renderer {
 	protected void writeStringAttribute(ResponseWriter responseWriter, Map<String, Object> attributes, String name,
 		String defaultValue, boolean lastAttribute) throws IOException {
 		String value = GetterUtil.getString(attributes.get(name), defaultValue);
-		writeStringAttribute(responseWriter, name, value, lastAttribute);
+		writeStringAttribute(responseWriter, name, value, lastAttribute, true);
 	}
 
 	@Override


### PR DESCRIPTION
The aui:dialog tag does not work with a title that contains a space. The problem is that the string is not quoted.
