### PR TITLE
Fix for isolated JSF deployment inside JBoss EAP 6.0.0

### DIFF
--- a/portal/src/main/java/com/liferay/faces/portal/lifecycle/LiferayLocalePhaseListener.java
+++ b/portal/src/main/java/com/liferay/faces/portal/lifecycle/LiferayLocalePhaseListener.java
@@ -21,6 +21,7 @@ import javax.faces.event.PhaseId;
 import javax.faces.event.PhaseListener;
 
 import com.liferay.faces.portal.context.LiferayFacesContext;
+import com.liferay.faces.portal.context.LiferayFacesContextImpl;
 import com.liferay.faces.util.logging.Logger;
 import com.liferay.faces.util.logging.LoggerFactory;
 
@@ -59,6 +60,10 @@ public class LiferayLocalePhaseListener implements PhaseListener {
 	private void setLocale() {
 
 		try {
+            //just needed if the JSF libraries are deployed with the portlet inside JBoss EAP 6.0.0
+            if (LiferayFacesContext.getInstance() == null) {
+                new LiferayFacesContextImpl();
+            }
 			LiferayFacesContext liferayFacesContext = LiferayFacesContext.getInstance();
 
 			// It's possible that the FacesServlet was invoked directly, and so this PhaseListener


### PR DESCRIPTION
Hello Neil
we're using a JBoss EAP 6.0.0 and want to deploy the jsf libs(api,impl) within the portlet itself. but now if we use the LiferayLocalePhaseListener there is always a nullpointer exception.
and the following log entry can be seen every time:

07:05:18,660 INFO  [stdout](http-localhost/127.0.0.1:9443-2) 07:05:18,659 ERROR LiferayFacesContext:41 - Instance not initialized -- caller might be static

So I made a little quickfix in the LiferayLocalePhaseListener Class to check if the LiferayFacesContext is null. If so I will initialize a new one. and from now on it works fine for me. 
So here is my pull request. if you got a better idea how to fix this issue i would appreciate your feedback.

Thanks a lot
Regards
Sven
