### PR TITLE
FACES-1769 removes the integration.context 

### DIFF
--- a/test/integration/demos/bridge/icefaces3-compat-portlet/src/test/java/com/liferay/faces/test/Icefaces3Compat.java
+++ b/test/integration/demos/bridge/icefaces3-compat-portlet/src/test/java/com/liferay/faces/test/Icefaces3Compat.java
@@ -90,7 +90,7 @@ public class Icefaces3Compat extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../following-sibling::*[1]/child::node()";
 
-	static final String url = baseUrl + webContext + "/ice3-compat";
+	static final String url = baseUrl + "/group/bridge-demos/ice3-compat";
 	
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/icefaces3-compat-portlet/src/test/java/com/liferay/faces/test/Icefaces3CompatPortletTest.java
+++ b/test/integration/demos/bridge/icefaces3-compat-portlet/src/test/java/com/liferay/faces/test/Icefaces3CompatPortletTest.java
@@ -95,7 +95,7 @@ public class Icefaces3CompatPortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../following-sibling::*[1]/child::node()";
 
-	static final String url = baseUrl + webContext + "/ice3-compat";
+	static final String url = baseUrl + "/group/bridge-demos/ice3-compat";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Icefaces3CompatPortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/icefaces3-crud-portlet/src/test/java/com/liferay/faces/test/Icefaces3CrudPortletTest.java
+++ b/test/integration/demos/bridge/icefaces3-crud-portlet/src/test/java/com/liferay/faces/test/Icefaces3CrudPortletTest.java
@@ -86,7 +86,7 @@ public class Icefaces3CrudPortletTest extends TesterBase {
 	// Cancel button
 	private static final String cancelButtonXpath = "//input[@type='submit' and @value='Cancel']";
 
-	static final String url = baseUrl + webContext + "/ice3-crud";
+	static final String url = baseUrl + "/group/bridge-demos/ice3-crud";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/icefaces3-portlet/src/test/java/com/liferay/faces/test/Icefaces3.java
+++ b/test/integration/demos/bridge/icefaces3-portlet/src/test/java/com/liferay/faces/test/Icefaces3.java
@@ -90,7 +90,7 @@ public class Icefaces3 extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../following-sibling::*[1]/child::node()";
 
-	static final String url = baseUrl + webContext + "/ice3";
+	static final String url = baseUrl + "/group/bridge-demos/ice3";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/icefaces3-portlet/src/test/java/com/liferay/faces/test/Icefaces3PortletTest.java
+++ b/test/integration/demos/bridge/icefaces3-portlet/src/test/java/com/liferay/faces/test/Icefaces3PortletTest.java
@@ -95,7 +95,7 @@ public class Icefaces3PortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../following-sibling::*[1]/child::node()";
 
-	static final String url = baseUrl + webContext + "/ice3";
+	static final String url = baseUrl + "/group/bridge-demos/ice3";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Icefaces3PortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/job-application-portlet/src/test/java/com/liferay/faces/test/JobPortletTest.java
+++ b/test/integration/demos/bridge/job-application-portlet/src/test/java/com/liferay/faces/test/JobPortletTest.java
@@ -95,7 +95,7 @@ public class JobPortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class JobPortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/jsf2-cdi-portlet/src/test/java/com/liferay/faces/test/Jsf2Cdi.java
+++ b/test/integration/demos/bridge/jsf2-cdi-portlet/src/test/java/com/liferay/faces/test/Jsf2Cdi.java
@@ -90,7 +90,7 @@ public class Jsf2Cdi extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2-cdi";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-cdi";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/jsf2-cdi-portlet/src/test/java/com/liferay/faces/test/Jsf2CdiPortletTest.java
+++ b/test/integration/demos/bridge/jsf2-cdi-portlet/src/test/java/com/liferay/faces/test/Jsf2CdiPortletTest.java
@@ -95,7 +95,7 @@ public class Jsf2CdiPortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2-cdi";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-cdi";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Jsf2CdiPortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/jsf2-events/src/test/java/com/liferay/faces/test/Jsf2EventsTest.java
+++ b/test/integration/demos/bridge/jsf2-events/src/test/java/com/liferay/faces/test/Jsf2EventsTest.java
@@ -62,7 +62,7 @@ public class Jsf2EventsTest extends TesterBase {
 	// <input type="submit" name="A8622:f1:j_idt28" value="Submit" id="aui_3_4_0_1_2331">
 	private static final String submitXpath = "//input[@type='submit' and @value='Submit']";
 
-	static final String url = baseUrl + webContext + "/jsf2-events";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-events";
 
 	@FindBy(xpath = briansInputXpath)
 	private WebElement briansInput;

--- a/test/integration/demos/bridge/jsf2-ipc-pub-render-params-portlet/src/test/java/com/liferay/faces/test/Jsf2IpcPubRenderParamsPortletTest.java
+++ b/test/integration/demos/bridge/jsf2-ipc-pub-render-params-portlet/src/test/java/com/liferay/faces/test/Jsf2IpcPubRenderParamsPortletTest.java
@@ -65,7 +65,7 @@ public class Jsf2IpcPubRenderParamsPortletTest extends TesterBase {
 	// <input type="submit" name="A8622:f1:j_idt28" value="Submit" id="aui_3_4_0_1_2331">
 	private static final String submitXpath = "//input[@type='submit' and @value='Submit']";
 
-	static final String url = baseUrl + webContext + "/jsf2-prp";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-prp";
 
 //	@FindBy(xpath = customerPortletDisplayNameXpath)
 //	private WebElement customerPortletDisplayName;

--- a/test/integration/demos/bridge/jsf2-jsp-portlet/src/test/java/com/liferay/faces/test/Jsf2Jsp.java
+++ b/test/integration/demos/bridge/jsf2-jsp-portlet/src/test/java/com/liferay/faces/test/Jsf2Jsp.java
@@ -92,7 +92,7 @@ public class Jsf2Jsp extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2-jsp";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-jsp";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/jsf2-jsp-portlet/src/test/java/com/liferay/faces/test/Jsf2JspPortletTest.java
+++ b/test/integration/demos/bridge/jsf2-jsp-portlet/src/test/java/com/liferay/faces/test/Jsf2JspPortletTest.java
@@ -95,7 +95,7 @@ public class Jsf2JspPortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2-jsp";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-jsp";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Jsf2JspPortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/jsf2-portlet/src/test/java/com/liferay/faces/test/Jsf2.java
+++ b/test/integration/demos/bridge/jsf2-portlet/src/test/java/com/liferay/faces/test/Jsf2.java
@@ -90,7 +90,7 @@ public class Jsf2 extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/jsf2-portlet/src/test/java/com/liferay/faces/test/Jsf2PortletTest.java
+++ b/test/integration/demos/bridge/jsf2-portlet/src/test/java/com/liferay/faces/test/Jsf2PortletTest.java
@@ -95,7 +95,7 @@ public class Jsf2PortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Jsf2PortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/jsf2-spring-portlet/src/test/java/com/liferay/faces/test/Jsf2Spring.java
+++ b/test/integration/demos/bridge/jsf2-spring-portlet/src/test/java/com/liferay/faces/test/Jsf2Spring.java
@@ -89,7 +89,7 @@ public class Jsf2Spring extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2-spring";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-spring";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/jsf2-spring-portlet/src/test/java/com/liferay/faces/test/Jsf2SpringPortletTest.java
+++ b/test/integration/demos/bridge/jsf2-spring-portlet/src/test/java/com/liferay/faces/test/Jsf2SpringPortletTest.java
@@ -95,7 +95,7 @@ public class Jsf2SpringPortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../child::node()";
 
-	static final String url = baseUrl + webContext + "/jsf2-spring";
+	static final String url = baseUrl + "/group/bridge-demos/jsf2-spring";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Jsf2SpringPortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/primefaces3-portlet/src/test/java/com/liferay/faces/test/Primefaces3.java
+++ b/test/integration/demos/bridge/primefaces3-portlet/src/test/java/com/liferay/faces/test/Primefaces3.java
@@ -91,7 +91,7 @@ public class Primefaces3 extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../following-sibling::*[1]/child::node()";
 
-	static final String url = baseUrl + webContext + "/prime3";
+	static final String url = baseUrl + "/group/bridge-demos/prime3";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/primefaces3-portlet/src/test/java/com/liferay/faces/test/Primefaces3PortletTest.java
+++ b/test/integration/demos/bridge/primefaces3-portlet/src/test/java/com/liferay/faces/test/Primefaces3PortletTest.java
@@ -95,7 +95,7 @@ public class Primefaces3PortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//input[contains(@id,':dateOfBirth')]/../following-sibling::*[1]/child::node()";
 
-	static final String url = baseUrl + webContext + "/prime3";
+	static final String url = baseUrl + "/group/bridge-demos/prime3";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Primefaces3PortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/demos/bridge/richfaces4-portlet/src/test/java/com/liferay/faces/test/Richfaces4.java
+++ b/test/integration/demos/bridge/richfaces4-portlet/src/test/java/com/liferay/faces/test/Richfaces4.java
@@ -90,7 +90,7 @@ public class Richfaces4 extends TesterBase {
 	// xpath for specific tests
 	protected static final String dateValidationXpath = "//span[contains(@id,':dateOfBirthField')]/span/span/span/span[contains(@id,':dateOfBirth')]/span";
 
-	static final String url = baseUrl + webContext + "/rich4";
+	static final String url = baseUrl + "/group/bridge-demos/rich4";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;

--- a/test/integration/demos/bridge/richfaces4-portlet/src/test/java/com/liferay/faces/test/Richfaces4PortletTest.java
+++ b/test/integration/demos/bridge/richfaces4-portlet/src/test/java/com/liferay/faces/test/Richfaces4PortletTest.java
@@ -95,7 +95,7 @@ public class Richfaces4PortletTest extends TesterBase {
 	// xpath for specific tests
 	private static final String dateValidationXpath = "//span[contains(@id,':dateOfBirthField')]/span/span/span/span[contains(@id,':dateOfBirth')]/span";
 
-	static final String url = baseUrl + webContext + "/rich4";
+	static final String url = baseUrl + "/group/bridge-demos/rich4";
 
 	@FindBy(xpath = formTagXpath)
 	private WebElement formTag;
@@ -179,7 +179,6 @@ public class Richfaces4PortletTest extends TesterBase {
 		logger.log(Level.INFO, "portal = " + portal);
 		logger.log(Level.INFO, "baseUrl = " + baseUrl);
 		logger.log(Level.INFO, "signInContext = " + signInContext);
-		logger.log(Level.INFO, "webContext = " + webContext);
 		
 		signIn();
 		

--- a/test/integration/pom.xml
+++ b/test/integration/pom.xml
@@ -41,7 +41,6 @@
 		<integration.host>localhost</integration.host>
 		<integration.port>8080</integration.port>
 		<integration.url>http://${integration.host}:${integration.port}</integration.url>
-		<integration.context>/group/bridge-demos</integration.context>
 		<integration.signin>/web/guest/home</integration.signin>
 	</properties>
 
@@ -50,7 +49,6 @@
 			<id>pluto</id>
 			<properties>
 				<integration.portal>pluto</integration.portal>
-				<integration.context>/pluto/portal</integration.context>
 				<integration.signin>/pluto/portal</integration.signin>
 			</properties>
 		</profile>
@@ -106,10 +104,6 @@
 							<property>
 								<name>integration.url</name>
 								<value>${integration.url}</value>
-							</property>
-							<property>
-								<name>integration.context</name>
-								<value>${integration.context}</value>
 							</property>
 							<property>
 								<name>integration.signin</name>

--- a/test/integration/util/src/main/java/com/liferay/faces/test/util/TesterBase.java
+++ b/test/integration/util/src/main/java/com/liferay/faces/test/util/TesterBase.java
@@ -93,7 +93,6 @@ public class TesterBase {
 	public static final String portal = System.getProperty("integration.portal", "liferay");
 	public static final String baseUrl = System.getProperty("integration.url", "http://localhost:8080");
 	public static final String signInContext = System.getProperty("integration.signin", "/web/guest/home");
-	public static final String webContext = System.getProperty("integration.context", "/web/bridge-demos/");
 	protected static final String signInUrl = baseUrl + signInContext;
 
 	@Drone


### PR DESCRIPTION
FACES-1769 removes the integration.context and the corresponding webContext from the bridge testers.  Let's the bridge testers decide which webContext to test.  Allows eclipse to run JUnit tests with those testers again.  Applied against 3.2.x.  But can be backported and forward ported.