### PR TITLE
FACES-1794

### DIFF
--- a/bridge-impl/src/main/java/com/liferay/faces/bridge/container/liferay/LiferayURLGeneratorBaseImpl.java
+++ b/bridge-impl/src/main/java/com/liferay/faces/bridge/container/liferay/LiferayURLGeneratorBaseImpl.java
@@ -282,7 +282,7 @@ public abstract class LiferayURLGeneratorBaseImpl implements LiferayURLGenerator
 			String outerPortletId = parameterMap.get(LiferayConstants.P_O_P_ID);
 
 			if (outerPortletId != null) {
-				appendParameterToURL(LiferayConstants.P_O_P_ID, parameterValue, url);
+				appendParameterToURL(LiferayConstants.P_O_P_ID, outerPortletId, url);
 			}
 
 			// Possibly add the doAsUserId parameter.


### PR DESCRIPTION
The p_o_p_id parameter's value is incorrectly appended to the URL in LiferayURLGeneratorBaseImpl.generateURL().
