### PR TITLE
Start working on Wildfly 8.0.0 support

### DIFF
--- a/demos/bridge/jsf2-cdi-portlet/src/main/webapp/WEB-INF/web-wildfly.xml
+++ b/demos/bridge/jsf2-cdi-portlet/src/main/webapp/WEB-INF/web-wildfly.xml
@@ -13,10 +13,10 @@
 		<param-name>javax.faces.PROJECT_STAGE</param-name>
 		<param-value>Development</param-value>
 	</context-param>
-	<!-- Instruct Mojarra to utilize JBoss-EL instead of the EL implementation provided by the servlet container. -->
+    <!-- https://github.com/wildfly/wildfly/pull/4802 WildfFly does not use jboss EL anymore !-->
 <!--	<context-param>
 		<param-name>com.sun.faces.expressionFactory</param-name>
-		<param-value>org.jboss.el.ExpressionFactoryImpl</param-value>
+		<param-value>com.sun.el.ExpressionFactoryImpl</param-value>
 	</context-param>!-->
 	<!-- Instruct Mojarra to namespace parameters according to NamingContainer rules. -->
 	<!-- JAVASERVERFACES-3031 -->

--- a/demos/bridge/jsf2-cdi-portlet/src/main/webapp/WEB-INF/web-wildfly.xml
+++ b/demos/bridge/jsf2-cdi-portlet/src/main/webapp/WEB-INF/web-wildfly.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+	<!-- Set the JSF 2 PROJECT_STAGE to Development so that the JSF implementation will do the following at runtime: -->
+	<!-- 1. Log more verbose messages. -->
+	<!-- 2. Render tips and/or warnings in the view markup. -->
+	<!-- 3. Cause the default ExceptionHandler to display a developer-friendly error page. -->
+	<context-param>
+		<param-name>javax.faces.PROJECT_STAGE</param-name>
+		<param-value>Development</param-value>
+	</context-param>
+	<!-- Instruct Mojarra to utilize JBoss-EL instead of the EL implementation provided by the servlet container. -->
+<!--	<context-param>
+		<param-name>com.sun.faces.expressionFactory</param-name>
+		<param-value>org.jboss.el.ExpressionFactoryImpl</param-value>
+	</context-param>!-->
+	<!-- Instruct Mojarra to namespace parameters according to NamingContainer rules. -->
+	<!-- JAVASERVERFACES-3031 -->
+	<!--
+	<context-param>
+		<param-name>com.sun.faces.namespaceParameters</param-name>
+		<param-value>true</param-value>
+	</context-param>
+	-->
+	<filter>
+		<filter-name>CDICrossContextFilter</filter-name>
+		<filter-class>com.liferay.cdi.portlet.bridge.CDICrossContextFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>CDICrossContextFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+		<dispatcher>INCLUDE</dispatcher>
+		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>ERROR</dispatcher>
+	</filter-mapping>
+	<filter>
+		<filter-name>WeldCrossContextFilter</filter-name>
+		<filter-class>org.jboss.weld.servlet.WeldCrossContextFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>WeldCrossContextFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+		<dispatcher>INCLUDE</dispatcher>
+		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>ERROR</dispatcher>
+	</filter-mapping>
+	<listener>
+		<listener-class>com.liferay.cdi.portlet.bridge.CDIContextListener</listener-class>
+	</listener>
+	<!-- Although the FacesServlet will not be invoked by any portlet requests, it is required to initialize JSF. -->
+	<servlet>
+		<servlet-name>Faces Servlet</servlet-name>
+		<servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	<!-- MyFaces will not initialize unless a servlet-mapping to the Faces Servlet is present. -->
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>*.xhtml</url-pattern>
+	</servlet-mapping>
+	<!-- Prevent direct access to Facelet view XHTML by the userAgent (browser). -->
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>Facelet View XHTML</web-resource-name>
+			<url-pattern>*.xhtml</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>nobody</role-name>
+		</auth-constraint>
+	</security-constraint>
+	<security-role>
+		<role-name>nobody</role-name>
+	</security-role>
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<module>demos</module>
 		<module>issues</module>
 		<module>support</module>
-		<!-- <module>test</module> !-->
+		<module>test</module>
 		<module>doc</module>
 	</modules>
 
@@ -1078,7 +1078,7 @@
 				<groupId>org.jboss.seam</groupId>
 				<artifactId>jboss-el</artifactId>
 				<version>2.0.0.GA</version>
-                <scope>${jboss-el.scope}</scope>
+				<scope>${jboss-el.scope}</scope>
 				<exclusions>
 					<exclusion>
 						<groupId>javax.el</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<module>demos</module>
 		<module>issues</module>
 		<module>support</module>
-		<module>test</module>
+		<!-- <module>test</module> !-->
 		<module>doc</module>
 	</modules>
 
@@ -96,6 +96,7 @@
 		<faces.impl.scope>compile</faces.impl.scope>
 		<faces.spec.version>2.2</faces.spec.version>
 		<faces.version>${mojarra.version}</faces.version>
+		<jboss-el.scope>compile</jboss-el.scope>
 		<full.version>${project.version} (${codename} / ${timestamp} AD)</full.version>
 		<icefaces3.version>3.3.0</icefaces3.version>
 		<jstl.version>1.2</jstl.version>
@@ -112,6 +113,7 @@
 		<liferay.glassfish.version>3.1.2.2</liferay.glassfish.version>
 		<liferay.home>${env.PORTALS_HOME}/liferay.com/${liferay.portal}-jsf-${faces.spec.version}</liferay.home>
 		<liferay.jboss.version>7.1.1</liferay.jboss.version>
+		<liferay.wildfly.version>8.0.0-SNAPSHOT</liferay.wildfly.version>
 		<liferay.jetty.version>8.1.10</liferay.jetty.version>
 		<liferay.jonas.version>5.2.3</liferay.jonas.version>
 		<liferay.maven.plugin.version>${liferay.version}</liferay.maven.plugin.version>
@@ -486,6 +488,24 @@
 				<war.packaging.excludes>
 					WEB-INF/ibm-*.xml,
 					WEB-INF/jboss-*.xml,
+					WEB-INF/web-*.xml,
+					WEB-INF/weblogic.xml
+				</war.packaging.excludes>
+			</properties>
+		</profile>
+		<profile>
+			<id>wildfly</id>
+			<properties>
+				<app.server.type>wildfly</app.server.type>
+				<faces.api.scope>provided</faces.api.scope>
+				<faces.impl.scope>provided</faces.impl.scope>
+				<jboss-el.scope>provided</jboss-el.scope>
+				<liferay.app.server.dir>${liferay.home}/jboss-${liferay.jboss.version}</liferay.app.server.dir>
+				<liferay.deploy.dir>${liferay.app.server.dir}/standalone/deployments</liferay.deploy.dir>
+				<war.packaging.excludes>
+					WEB-INF/glassfish-*.xml,
+					WEB-INF/ibm-*.xml,
+					WEB-INF/sun-*.xml,
 					WEB-INF/web-*.xml,
 					WEB-INF/weblogic.xml
 				</war.packaging.excludes>
@@ -1058,6 +1078,7 @@
 				<groupId>org.jboss.seam</groupId>
 				<artifactId>jboss-el</artifactId>
 				<version>2.0.0.GA</version>
+                <scope>${jboss-el.scope}</scope>
 				<exclusions>
 					<exclusion>
 						<groupId>javax.el</groupId>


### PR DESCRIPTION
Adds Wildfly profile and fixes deployment of jsf-cdi-portlet.
WF removes the usage of jboss-el and uses servleet 3.1.