### PR TITLE
 Fix ALLOY_CLASS_NAME in renderer base class

### DIFF
--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputsourcecode/InputSourceCodeRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputsourcecode/InputSourceCodeRenderer.java
@@ -44,7 +44,6 @@ import com.liferay.faces.util.render.HiddenTextResponseWriter;
 public class InputSourceCodeRenderer extends InputSourceCodeRendererBase {
 
 	// Private Constants
-	private static final String ALLOY_CLASS_NAME = "AceEditor";
 	private static final String ESCAPED_BACKSLASH = "\\\\";
 	private static final String ESCAPED_DOUBLE_QUOTE = "\\\\\"";
 	private static final String ESCAPED_BACKSLASH_DOUBLE_QUOTE = ESCAPED_BACKSLASH + ESCAPED_DOUBLE_QUOTE;
@@ -139,11 +138,6 @@ public class InputSourceCodeRenderer extends InputSourceCodeRendererBase {
 		}
 
 		super.encodeValue(responseWriter, InputSourceCodeAlloy, value, first);
-	}
-
-	@Override
-	public String getAlloyClassName() {
-		return ALLOY_CLASS_NAME;
 	}
 
 	@Override

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputsourcecode/InputSourceCodeRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputsourcecode/InputSourceCodeRendererBase.java
@@ -30,7 +30,7 @@ import com.liferay.faces.alloy.renderkit.DelegatingAlloyRendererBase;
 public abstract class InputSourceCodeRendererBase extends DelegatingAlloyRendererBase {
 
 	// Private Constants
-	private static final String ALLOY_CLASS_NAME = "InputSourceCode";
+	private static final String ALLOY_CLASS_NAME = "AceEditor";
 	private static final String ALLOY_MODULE_NAME = "aui-ace-editor";
 
 	// Protected Constants

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/outputremainingchars/OutputRemainingCharsRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/outputremainingchars/OutputRemainingCharsRenderer.java
@@ -44,7 +44,6 @@ import com.liferay.faces.util.lang.StringPool;
 public class OutputRemainingCharsRenderer extends OutputRemainingCharsRendererBase {
 
 	// Private Constants
-	private static final String ALLOY_CLASS_NAME = "CharCounter";
 	private static final String ALLOY_MAX_LENGTH_EVENT_NAME = "maxLength";
 
 	@Override
@@ -185,11 +184,6 @@ public class OutputRemainingCharsRenderer extends OutputRemainingCharsRendererBa
 				}
 			}
 		}
-	}
-
-	@Override
-	public String getAlloyClassName() {
-		return ALLOY_CLASS_NAME;
 	}
 
 	@Override

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/outputremainingchars/OutputRemainingCharsRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/outputremainingchars/OutputRemainingCharsRendererBase.java
@@ -30,7 +30,7 @@ import com.liferay.faces.alloy.renderkit.DelegatingAlloyRendererBase;
 public abstract class OutputRemainingCharsRendererBase extends DelegatingAlloyRendererBase {
 
 	// Private Constants
-	private static final String ALLOY_CLASS_NAME = "OutputRemainingChars";
+	private static final String ALLOY_CLASS_NAME = "CharCounter";
 	private static final String ALLOY_MODULE_NAME = "aui-char-counter";
 
 	// Protected Constants

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/selectstarrating/SelectStarRatingRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/selectstarrating/SelectStarRatingRenderer.java
@@ -45,9 +45,6 @@ import com.liferay.faces.util.render.RendererUtil;
 public class SelectStarRatingRenderer extends SelectStarRatingRendererBase {
 
 	// Private Constants
-	private static final String ALLOY_CLASS_NAME = "StarRating";
-
-	// Private Constants
 	private static final String FACES_RUNTIME_ONCLICK = "facesRuntimeOnClick";
 	private static final String SELECTED_INDEX = "selectedIndex";
 	private static final String DEFAULT_SELECTED_VALUE = "defaultSelectedValue";
@@ -270,11 +267,6 @@ public class SelectStarRatingRenderer extends SelectStarRatingRendererBase {
 		// Finish the encoding of the outermost </span> element.
 		ResponseWriter responseWriter = facesContext.getResponseWriter();
 		responseWriter.endElement(StringPool.SPAN);
-	}
-
-	@Override
-	public String getAlloyClassName() {
-		return ALLOY_CLASS_NAME;
 	}
 
 	@Override

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/selectstarrating/SelectStarRatingRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/selectstarrating/SelectStarRatingRendererBase.java
@@ -30,7 +30,7 @@ import com.liferay.faces.alloy.renderkit.DelegatingAlloyRendererBase;
 public abstract class SelectStarRatingRendererBase extends DelegatingAlloyRendererBase {
 
 	// Private Constants
-	private static final String ALLOY_CLASS_NAME = "SelectStarRating";
+	private static final String ALLOY_CLASS_NAME = "Rating";
 	private static final String ALLOY_MODULE_NAME = "aui-rating";
 
 	// Protected Constants


### PR DESCRIPTION
FACES-1915 alloy:selectStarRating: Fix ALLOY_CLASS_NAME in renderer base class and remove ALLOY_CLASS_NAME and getAlloyClassName() method from subclass.
FACES-1921 alloy:outputRemainingChars: Fix ALLOY_CLASS_NAME in renderer base class and remove ALLOY_CLASS_NAME and getAlloyClassName() method from subclass.
FACES-1903 alloy:inputSourceCode: Fix ALLOY_CLASS_NAME in renderer base class and remove ALLOY_CLASS_NAME and getAlloyClassName() method from subclass.
