### PR TITLE
FACES-1895 & FACES-1897

### DIFF
--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDate.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDate.java
@@ -100,8 +100,7 @@ public class InputDate extends InputDateBase {
 							SimpleDateFormat simpleDateFormat = new SimpleDateFormat(datePattern);
 							String minDateString = simpleDateFormat.format(minDate);
 							String maxDateString = simpleDateFormat.format(maxDate);
-							Object objectLocale = getLocale();
-							Locale locale = PickDateUtil.determineLocale(facesContext, objectLocale);
+							Locale locale = PickDateUtil.getObjectAsLocale(getLocale(facesContext));
 							String message = messageContext.getMessage(locale, "please-enter-a-value-between-x-and-x",
 									minDateString, maxDateString);
 							facesMessage = new FacesMessage(FacesMessage.SEVERITY_ERROR, message, message);
@@ -142,6 +141,9 @@ public class InputDate extends InputDateBase {
 			DateTimeConverter dateTimeConverter = new DateTimeConverter();
 			String datePattern = getDatePattern();
 			dateTimeConverter.setPattern(datePattern);
+			Object objectLocale = getLocale();
+			Locale locale = PickDateUtil.getObjectAsLocale(objectLocale);
+			dateTimeConverter.setLocale(locale);
 
 			// DateTimeConverter has a default time zone of GMT. Set the time zone to null to ensure that the time
 			// zone is not involved in Date conversion.
@@ -160,12 +162,20 @@ public class InputDate extends InputDateBase {
 		if (datePattern == null) {
 
 			// Provide a default datePattern based on the locale.
-			FacesContext facesContext = FacesContext.getCurrentInstance();
 			Object locale = getLocale();
-			datePattern = PickDateUtil.getDefaultDatePattern(facesContext, locale);
+			datePattern = PickDateUtil.getDefaultDatePattern(locale);
 		}
 
 		return datePattern;
+	}
+
+	@Override
+	public Object getLocale() {
+		return getLocale(null);
+	}
+
+	public Object getLocale(FacesContext facesContext) {
+		return PickDateUtil.determineLocale(facesContext, super.getLocale());
 	}
 
 	@Override

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDateRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDateRenderer.java
@@ -64,7 +64,7 @@ public class InputDateRenderer extends InputDateRendererBase {
 		pickDate.setAutoHide(inputDate.isAutoHide());
 		pickDate.setDatePattern(datePattern);
 		pickDate.setFor(trigger);
-		pickDate.setLocale(inputDate.getLocale());
+		pickDate.setLocale(inputDate.getLocale(facesContext));
 		pickDate.setMaximumDate(inputDate.getMaximumDate());
 		pickDate.setMinimumDate(inputDate.getMinimumDate());
 		pickDate.setPanes(inputDate.getPanes());

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDate.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDate.java
@@ -47,9 +47,8 @@ public class PickDate extends PickDateBase {
 		if (datePattern == null) {
 
 			// Provide a default datePattern based on the locale.
-			FacesContext facesContext = FacesContext.getCurrentInstance();
 			Object locale = getLocale();
-			datePattern = PickDateUtil.getDefaultDatePattern(facesContext, locale);
+			datePattern = PickDateUtil.getDefaultDatePattern(locale);
 		}
 
 		return datePattern;
@@ -58,6 +57,15 @@ public class PickDate extends PickDateBase {
 	@Override
 	public String getFamily() {
 		return COMPONENT_FAMILY;
+	}
+
+	@Override
+	public Object getLocale() {
+		return getLocale(null);
+	}
+
+	public Object getLocale(FacesContext facesContext) {
+		return PickDateUtil.determineLocale(facesContext, super.getLocale());
 	}
 
 	public String getOnDateClick() {

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRenderer.java
@@ -65,7 +65,7 @@ public class PickDateRenderer extends PickDateRendererBase {
 		throws IOException {
 
 		PickDate pickDate = (PickDate) uiComponent;
-		Locale locale = PickDateUtil.determineLocale(facesContext, pickDate.getLocale());
+		Locale locale = PickDateUtil.getObjectAsLocale(pickDate.getLocale(facesContext));
 
 		// RFC 1766 requires the subtags of locales to be delimited by hyphens rather than underscores.
 		// http://www.faqs.org/rfcs/rfc1766.html
@@ -210,8 +210,7 @@ public class PickDateRenderer extends PickDateRendererBase {
 		// specified a locale other than that of the server or view root. If so, then the javascript must be rendered
 		// inline.
 		PickDate pickDate = (PickDate) uiComponent;
-		Object componentLocale = pickDate.getLocale();
-		Locale locale = PickDateUtil.determineLocale(facesContext, componentLocale);
+		Locale locale = PickDateUtil.getObjectAsLocale(pickDate.getLocale(facesContext));
 		UIViewRoot viewRoot = facesContext.getViewRoot();
 		Locale viewRootLocale = viewRoot.getLocale();
 

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateUtil.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateUtil.java
@@ -63,11 +63,13 @@ public class PickDateUtil {
 	private static final String YY = "yy";
 	private static final String YYYY = "yyyy";
 
-	public static Locale determineLocale(FacesContext facesContext, Object objectLocale) {
-
-		Locale locale = getObjectAsLocale(objectLocale);
+	public static Object determineLocale(FacesContext facesContext, Object locale) {
 
 		if (locale == null) {
+
+			if (facesContext == null) {
+				facesContext = FacesContext.getCurrentInstance();
+			}
 
 			UIViewRoot viewRoot = facesContext.getViewRoot();
 			locale = viewRoot.getLocale();
@@ -110,9 +112,9 @@ public class PickDateUtil {
 		return calendar.getTime();
 	}
 
-	public static String getDefaultDatePattern(FacesContext facesContext, Object componentLocale) {
+	public static String getDefaultDatePattern(Object componentLocale) {
 
-		Locale locale = PickDateUtil.determineLocale(facesContext, componentLocale);
+		Locale locale = getObjectAsLocale(componentLocale);
 
 		// Note: The following usage of SimpleDateFormat is thread-safe, since only the result of the toPattern()
 		// method is utilized.


### PR DESCRIPTION
FACES-1895 Develop alloy:pickDate component (Overloaded getLocale() method to take FacesContext argument. Moved PickDateUtil.determineLocale() usage from PickDateRenderer to PickDate.getLocale() to be consistent with other getters (e.g. getters provide default values).)
FACES-1897 Develop alloy:inputDate component (Overloaded getLocale() method to take FacesContext argument. Moved PickDateUtil.determineLocale() usage to InputDate.getLocale() to be consistent with other getters (e.g. getters provide default values).)
