### PR TITLE
FACES-1895

### DIFF
--- a/alloy/components-ext.xml
+++ b/alloy/components-ext.xml
@@ -1497,10 +1497,10 @@
 			</attribute>
 			<attribute>
 				<description>
-					<![CDATA[The time zone for the built-in DateTimeConverter.]]>
+					<![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>.]]>
 				</description>
-				<type>java.lang.Object</type>
 				<name>timeZone</name>
+				<type>java.lang.Object</type>
 			</attribute>
 		</attributes>
 	</component>
@@ -1931,6 +1931,13 @@
 				</description>
 				<name>selectionMode</name>
 				<type>java.lang.String</type>
+			</attribute>
+			<attribute>
+				<description>
+					<![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>. This attribute is used to determine the time zone of <code>java.text.SimpleDateFormat</code> which is used to parse the <code>minimumDate</code> and <code>maximumDate</code> attributes. If <code>minimumDate</code> and maximumDate</code> are not Strings or are unused, it is not necessary to set this attribute.]]>
+				</description>
+				<name>timeZone</name>
+				<type>java.lang.Object</type>
 			</attribute>
 		</attributes>
 	</component>

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDate.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDate.java
@@ -25,7 +25,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.DateTimeConverter;
 
-import com.liferay.faces.alloy.component.inputdatetime.InputDateTimeUtil;
 import com.liferay.faces.alloy.component.pickdate.PickDateUtil;
 import com.liferay.faces.util.component.ComponentUtil;
 import com.liferay.faces.util.context.MessageContext;
@@ -44,6 +43,7 @@ public class InputDate extends InputDateBase {
 
 	// Private Constants
 	private static final String CALENDAR = "calendar";
+	private static final String GREENWICH = "Greenwich";
 
 	public InputDate() {
 		super();
@@ -62,10 +62,12 @@ public class InputDate extends InputDateBase {
 				// Get all necessary dates.
 				String datePattern = getDatePattern();
 				Object minimumDate = getMinimumDate();
-				Date minDate = PickDateUtil.getObjectAsDate(minimumDate, datePattern);
+				Object timeZoneObject = getTimeZone();
+				TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(timeZoneObject);
+				Date minDate = PickDateUtil.getObjectAsDate(minimumDate, datePattern, timeZone);
 				Object maximumDate = getMaximumDate();
-				Date maxDate = PickDateUtil.getObjectAsDate(maximumDate, datePattern);
-				Date submittedDate = PickDateUtil.getObjectAsDate(newValue, datePattern);
+				Date maxDate = PickDateUtil.getObjectAsDate(maximumDate, datePattern, timeZone);
+				Date submittedDate = PickDateUtil.getObjectAsDate(newValue, datePattern, timeZone);
 
 				if ((minDate == null) && (maxDate == null)) {
 					setValid(true);
@@ -82,7 +84,6 @@ public class InputDate extends InputDateBase {
 					// Set the times to midnight for comparison purposes.
 					minDate = PickDateUtil.getDateAtMidnight(minDate);
 					maxDate = PickDateUtil.getDateAtMidnight(maxDate);
-					submittedDate = PickDateUtil.getDateAtMidnight(submittedDate);
 
 					// To determine if the submitted value is valid, check if it falls between the minimum date and
 					// the maximum date.
@@ -149,7 +150,7 @@ public class InputDate extends InputDateBase {
 			dateTimeConverter.setLocale(locale);
 
 			Object objectTimeZone = getTimeZone();
-			TimeZone timeZone = InputDateTimeUtil.getObjectAsTimeZone(objectTimeZone);
+			TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(objectTimeZone);
 			dateTimeConverter.setTimeZone(timeZone);
 			converter = dateTimeConverter;
 		}
@@ -189,5 +190,16 @@ public class InputDate extends InputDateBase {
 		String styleClass = (String) getStateHelper().eval(PropertyKeys.styleClass, null);
 
 		return ComponentUtil.concatCssClasses(styleClass, STYLE_CLASS_NAME);
+	}
+
+	@Override
+	public Object getTimeZone() {
+		Object timeZone = super.getTimeZone();
+
+		if (timeZone == null) {
+			timeZone = TimeZone.getTimeZone(GREENWICH);
+		}
+
+		return timeZone;
 	}
 }

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDateRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDateRenderer.java
@@ -69,6 +69,7 @@ public class InputDateRenderer extends InputDateRendererBase {
 		pickDate.setMinimumDate(inputDate.getMinimumDate());
 		pickDate.setPanes(inputDate.getPanes());
 		pickDate.setStyleClass(inputDate.getStyleClass());
+		pickDate.setTimeZone(inputDate.getTimeZone());
 		pickDate.setzIndex(inputDate.getzIndex());
 
 		String showOn = inputDate.getShowOn();

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdatetime/InputDateTimeUtil.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdatetime/InputDateTimeUtil.java
@@ -13,9 +13,6 @@
  */
 package com.liferay.faces.alloy.component.inputdatetime;
 
-import java.util.TimeZone;
-
-import javax.faces.FacesException;
 import javax.faces.component.UINamingContainer;
 import javax.faces.context.FacesContext;
 
@@ -32,36 +29,4 @@ public class InputDateTimeUtil {
 
 		return separatorChar + StringPool.INPUT;
 	}
-
-	public static TimeZone getObjectAsTimeZone(Object timeZoneAsObject) throws FacesException {
-
-		TimeZone timeZone = null;
-
-		if (timeZoneAsObject != null) {
-
-			if (timeZoneAsObject instanceof TimeZone) {
-				timeZone = (TimeZone) timeZoneAsObject;
-			}
-			else if (timeZoneAsObject instanceof String) {
-
-				String timeZoneAsString = (String) timeZoneAsObject;
-
-				if (timeZoneAsString.length() > 0) {
-
-					// Note: The following usage of TimeZone is thread-safe, since only the result of the getTimeZone()
-					// method is utilized.
-					timeZone = TimeZone.getTimeZone(timeZoneAsString);
-				}
-			}
-			else {
-
-				String message = "Unable to convert value to TimeZone.";
-				FacesException facesException = new FacesException(message);
-				throw facesException;
-			}
-		}
-
-		return timeZone;
-	}
-
 }

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDate.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDate.java
@@ -13,6 +13,8 @@
  */
 package com.liferay.faces.alloy.component.pickdate;
 
+import java.util.TimeZone;
+
 import javax.faces.component.FacesComponent;
 import javax.faces.context.FacesContext;
 
@@ -33,6 +35,7 @@ public class PickDate extends PickDateBase {
 
 	// Private Constants
 	private static final String ON_DATE_CLICK = "onDateClick";
+	private static final String GREENWICH = "Greenwich";
 
 	public PickDate() {
 		super();
@@ -84,5 +87,16 @@ public class PickDate extends PickDateBase {
 		String styleClass = (String) getStateHelper().eval(PickDatePropertyKeys.styleClass, null);
 
 		return ComponentUtil.concatCssClasses(styleClass, STYLE_CLASS_NAME);
+	}
+
+	@Override
+	public Object getTimeZone() {
+		Object timeZone = super.getTimeZone();
+
+		if (timeZone == null) {
+			timeZone = TimeZone.getTimeZone(GREENWICH);
+		}
+
+		return timeZone;
 	}
 }

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateBase.java
@@ -41,6 +41,7 @@ public abstract class PickDateBase extends UIComponentBase implements Styleable,
 		selectionMode,
 		style,
 		styleClass,
+		timeZone,
 		zIndex
 	}
 
@@ -144,6 +145,14 @@ public abstract class PickDateBase extends UIComponentBase implements Styleable,
 	@Override
 	public void setStyleClass(String styleClass) {
 		getStateHelper().put(PickDatePropertyKeys.styleClass, styleClass);
+	}
+
+	public Object getTimeZone() {
+		return (Object) getStateHelper().eval(PickDatePropertyKeys.timeZone, null);
+	}
+
+	public void setTimeZone(Object timeZone) {
+		getStateHelper().put(PickDatePropertyKeys.timeZone, timeZone);
 	}
 
 	public Integer getzIndex() {

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRenderer.java
@@ -16,6 +16,7 @@ package com.liferay.faces.alloy.component.pickdate;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
@@ -101,8 +102,10 @@ public class PickDateRenderer extends PickDateRendererBase {
 
 		if (maximumDate != null) {
 
-			Date maxDate = PickDateUtil.getObjectAsDate(maximumDate, componentDatePattern);
-			String maxDateString = PickDateUtil.toJavascriptDateString(maxDate);
+			Object timeZoneObject = pickDate.getTimeZone();
+			TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(timeZoneObject);
+			Date maxDate = PickDateUtil.getObjectAsDate(maximumDate, componentDatePattern, timeZone);
+			String maxDateString = PickDateUtil.toJavascriptDateString(maxDate, timeZone);
 			encodeNonEscapedObject(responseWriter, MAXIMUM_DATE, maxDateString, calendarFirst);
 			calendarFirst = false;
 		}
@@ -111,8 +114,10 @@ public class PickDateRenderer extends PickDateRendererBase {
 
 		if (minimumDate != null) {
 
-			Date minDate = PickDateUtil.getObjectAsDate(minimumDate, componentDatePattern);
-			String minDateString = PickDateUtil.toJavascriptDateString(minDate);
+			Object timeZoneObject = pickDate.getTimeZone();
+			TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(timeZoneObject);
+			Date minDate = PickDateUtil.getObjectAsDate(minimumDate, componentDatePattern, timeZone);
+			String minDateString = PickDateUtil.toJavascriptDateString(minDate, timeZone);
 			encodeNonEscapedObject(responseWriter, MINIMUM_DATE, minDateString, calendarFirst);
 			calendarFirst = false;
 		}

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRendererBase.java
@@ -42,6 +42,7 @@ public abstract class PickDateRendererBase extends AlloyRendererBase {
 	protected static final String SELECTION_MODE = "selectionMode";
 	protected static final String STYLE = "style";
 	protected static final String STYLE_CLASS = "styleClass";
+	protected static final String TIME_ZONE = "timeZone";
 	protected static final String TRIGGER = "trigger";
 	protected static final String Z_INDEX = "zIndex";
 

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateUtil.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateUtil.java
@@ -20,6 +20,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import javax.faces.FacesException;
 import javax.faces.component.UIViewRoot;
@@ -40,11 +41,14 @@ public class PickDateUtil {
 	private static final String EEE = "EEE";
 	private static final String EEEE = "EEEE";
 	private static final String FF = "FF";
+
+	// This date pattern is used by the JavaScript to create a new Date object, so each month needs to be reduced by 1
+	// to be correct.
+	private static final String JAVASCRIPT_NEW_DATE_PATTERN = "'new Date'(yyyy,MM-1,dd,0,0,0,0)";
 	private static final String M = "M";
 	private static final String MM = "MM";
 	private static final String MMM = "MMM";
 	private static final String MMMMM = "MMMMM";
-	private static final String NEW_DATE = "new Date";
 	private static final String PERCENT_A_LOWER = "%a";
 	private static final String PERCENT_A_UPPER = "%A";
 	private static final String PERCENT_B_LOWER = "%b";
@@ -74,26 +78,12 @@ public class PickDateUtil {
 		return locale;
 	}
 
-	public static String toJavascriptDateString(Date date) {
+	public static String toJavascriptDateString(Date date, TimeZone timeZone) {
 
-		Calendar calendar = new GregorianCalendar();
-		calendar.setTime(date);
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(JAVASCRIPT_NEW_DATE_PATTERN);
+		simpleDateFormat.setTimeZone(timeZone);
 
-		int minYear = calendar.get(Calendar.YEAR);
-		int minMonth = calendar.get(Calendar.MONTH);
-		int minDay = calendar.get(Calendar.DAY_OF_MONTH);
-
-		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append(NEW_DATE);
-		stringBuilder.append(StringPool.OPEN_PARENTHESIS);
-		stringBuilder.append(minYear);
-		stringBuilder.append(StringPool.COMMA);
-		stringBuilder.append(minMonth);
-		stringBuilder.append(StringPool.COMMA);
-		stringBuilder.append(minDay);
-		stringBuilder.append(StringPool.CLOSE_PARENTHESIS);
-
-		return stringBuilder.toString();
+		return simpleDateFormat.format(date);
 	}
 
 	public static Date getDateAtMidnight(Date date) {
@@ -148,7 +138,8 @@ public class PickDateUtil {
 		return mask;
 	}
 
-	public static Date getObjectAsDate(Object dateAsObject, String datePattern) throws FacesException {
+	public static Date getObjectAsDate(Object dateAsObject, String datePattern, TimeZone timeZone)
+		throws FacesException {
 
 		Date date = null;
 
@@ -166,7 +157,7 @@ public class PickDateUtil {
 					try {
 
 						SimpleDateFormat simpleDateFormat = new SimpleDateFormat(datePattern);
-
+						simpleDateFormat.setTimeZone(timeZone);
 						date = simpleDateFormat.parse(dateAsString);
 					}
 					catch (ParseException e) {
@@ -220,5 +211,36 @@ public class PickDateUtil {
 		}
 
 		return locale;
+	}
+
+	public static TimeZone getObjectAsTimeZone(Object timeZoneAsObject) throws FacesException {
+
+		TimeZone timeZone = null;
+
+		if (timeZoneAsObject != null) {
+
+			if (timeZoneAsObject instanceof TimeZone) {
+				timeZone = (TimeZone) timeZoneAsObject;
+			}
+			else if (timeZoneAsObject instanceof String) {
+
+				String timeZoneAsString = (String) timeZoneAsObject;
+
+				if (timeZoneAsString.length() > 0) {
+
+					// Note: The following usage of TimeZone is thread-safe, since only the result of the getTimeZone()
+					// method is utilized.
+					timeZone = TimeZone.getTimeZone(timeZoneAsString);
+				}
+			}
+			else {
+
+				String message = "Unable to convert value to TimeZone.";
+				FacesException facesException = new FacesException(message);
+				throw facesException;
+			}
+		}
+
+		return timeZone;
 	}
 }

--- a/alloy/src/main/resources/META-INF/alloy.taglib.xml
+++ b/alloy/src/main/resources/META-INF/alloy.taglib.xml
@@ -1920,7 +1920,7 @@
 			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
-			<description><![CDATA[The time zone for the built-in DateTimeConverter.]]></description>
+			<description><![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>.]]></description>
 			<name>timeZone</name>
 			<required>false</required>
 			<type>java.lang.Object</type>
@@ -4727,6 +4727,12 @@
 			<name>styleClass</name>
 			<required>false</required>
 			<type>java.lang.String</type>
+		</attribute>
+		<attribute>
+			<description><![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>. This attribute is used to determine the time zone of <code>java.text.SimpleDateFormat</code> which is used to parse the <code>minimumDate</code> and <code>maximumDate</code> attributes. If <code>minimumDate</code> and maximumDate</code> are not Strings or are unused, it is not necessary to set this attribute.]]></description>
+			<name>timeZone</name>
+			<required>false</required>
+			<type>java.lang.Object</type>
 		</attribute>
 		<attribute>
 			<description><![CDATA[Specifies the stack order of the component. The default value is a constant from the Liferay.zIndex JavaScript object.]]></description>

--- a/demos/showcase/showcase-webapp/src/main/java/com/liferay/faces/demos/bean/InputDateModelBean.java
+++ b/demos/showcase/showcase-webapp/src/main/java/com/liferay/faces/demos/bean/InputDateModelBean.java
@@ -17,6 +17,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.RequestScoped;
@@ -33,18 +34,6 @@ public class InputDateModelBean {
 	private Locale locale;
 	private Date maxDate;
 	private Date minDate;
-
-	private Calendar newCalendar() {
-
-		Calendar calendar = new GregorianCalendar();
-
-		// https://issues.liferay.com/browse/AUI-1177
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-
-		return calendar;
-	}
 
 	public Date getBirthday() {
 		return birthday;
@@ -67,7 +56,7 @@ public class InputDateModelBean {
 
 		if (maxDate == null) {
 
-			Calendar calendar = newCalendar();
+			Calendar calendar = new GregorianCalendar();
 			calendar.add(Calendar.MONTH, 2);
 			maxDate = calendar.getTime();
 		}
@@ -79,7 +68,7 @@ public class InputDateModelBean {
 
 		if (minDate == null) {
 
-			Calendar calendar = newCalendar();
+			Calendar calendar = new GregorianCalendar();
 			calendar.add(Calendar.MONTH, -2);
 			minDate = calendar.getTime();
 		}

--- a/demos/showcase/showcase-webapp/src/main/java/com/liferay/faces/demos/bean/PickDateModelBean.java
+++ b/demos/showcase/showcase-webapp/src/main/java/com/liferay/faces/demos/bean/PickDateModelBean.java
@@ -35,18 +35,6 @@ public class PickDateModelBean {
 	private Date minDate;
 	private String multiple;
 
-	private Calendar newCalendar() {
-
-		Calendar calendar = new GregorianCalendar();
-
-		// https://issues.liferay.com/browse/AUI-1177
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-
-		return calendar;
-	}
-
 	public Date getBirthday() {
 		return birthday;
 	}
@@ -68,7 +56,7 @@ public class PickDateModelBean {
 
 		if (maxDate == null) {
 
-			Calendar calendar = newCalendar();
+			Calendar calendar = new GregorianCalendar();
 			calendar.add(Calendar.MONTH, 2);
 			maxDate = calendar.getTime();
 		}
@@ -80,7 +68,7 @@ public class PickDateModelBean {
 
 		if (minDate == null) {
 
-			Calendar calendar = newCalendar();
+			Calendar calendar = new GregorianCalendar();
 			calendar.add(Calendar.MONTH, -2);
 			minDate = calendar.getTime();
 		}

--- a/demos/showcase/showcase-webapp/src/main/webapp/component/alloy/inputdate/min-max-date/inputDate.xhtml
+++ b/demos/showcase/showcase-webapp/src/main/webapp/component/alloy/inputdate/min-max-date/inputDate.xhtml
@@ -7,16 +7,17 @@
 		<h:form>
 			<showcase:example>
 				<alloy:inputDate id="birthday" datePattern="MM/dd/yyyy" maximumDate="#{inputDateModelBean.maxDate}"
-					minimumDate="#{inputDateModelBean.minDate}" showOn="button" value="#{inputDateModelBean.birthday}" />
+					minimumDate="#{inputDateModelBean.minDate}" showOn="button" value="#{inputDateModelBean.birthday}"
+					timeZone="America/New_York" />
 				<alloy:message for="birthday" />
 				<br />
 				<alloy:outputText value="#{i18n['valid-date-range']}: " />
 				<alloy:outputText value="#{inputDateModelBean.minDate}">
-					<f:convertDateTime pattern="MM/dd/yyyy" />
+					<f:convertDateTime pattern="MM/dd/yyyy" timeZone="America/New_York" />
 				</alloy:outputText>
 				<alloy:outputText value=" - " />
 				<alloy:outputText value="#{inputDateModelBean.maxDate}">
-					<f:convertDateTime pattern="MM/dd/yyyy" />
+					<f:convertDateTime pattern="MM/dd/yyyy" timeZone="America/New_York" />
 				</alloy:outputText>
 				<hr />
 				<alloy:commandButton value="#{i18n['submit']}">
@@ -25,7 +26,7 @@
 			</showcase:example>
 			<showcase:outputModel>
 				<alloy:outputText id="modelValue" value="#{inputDateModelBean.birthday}">
-					<f:convertDateTime pattern="MM/dd/yyyy" />
+					<f:convertDateTime pattern="MM/dd/yyyy" timeZone="America/New_York" />
 				</alloy:outputText>
 			</showcase:outputModel>
 		</h:form>


### PR DESCRIPTION
FACES-1895 Develop alloy:pickDate component (Added timeZone attribute. The attribute allows developers to specify a time zone for the SimpleDateFormat used to parse minimumDate and maximumDate if they are Strings.)
FACES-1897 Develop alloy:inputDate component (Added timeZone attribute. The attribute allows developers to specify the timeZone of the built-in converter and pickDate. The timeZone attribute is also used for the SimpleDateFormat which parse minimumDate and maximumDate if they are Strings.)
FACES-1714 Develop Liferay Faces Showcase (Specified the new timeZone attribute in the appropriate example for inputDate. Removed unnecessary code in model beans which set hours, minutes, and seconds to 0.)
