### PR TITLE
FACES-1895 & FACES-1897

### DIFF
--- a/alloy/components-ext.xml
+++ b/alloy/components-ext.xml
@@ -1554,10 +1554,10 @@
 			</attribute>
 			<attribute>
 				<description>
-					<![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>.]]>
+					<![CDATA[The time zone of the component (defaults to "Greenwich").]]>
 				</description>
 				<name>timeZone</name>
-				<type>java.lang.Object</type>
+				<type>java.lang.String</type>
 			</attribute>
 		</attributes>
 	</component>
@@ -1991,10 +1991,10 @@
 			</attribute>
 			<attribute>
 				<description>
-					<![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>. This attribute is used to determine the time zone of <code>java.text.SimpleDateFormat</code> which is used to parse the <code>minimumDate</code> and <code>maximumDate</code> attributes. If <code>minimumDate</code> and maximumDate</code> are not Strings or are unused, it is not necessary to set this attribute.]]>
+					<![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute is used to determine the time zone of <code>java.text.SimpleDateFormat</code> which is used to parse the <code>minimumDate</code> and <code>maximumDate</code> attributes. If <code>minimumDate</code> and maximumDate</code> are not Strings or are unused, it is not necessary to set this attribute.]]>
 				</description>
 				<name>timeZone</name>
-				<type>java.lang.Object</type>
+				<type>java.lang.String</type>
 			</attribute>
 		</attributes>
 	</component>

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDate.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDate.java
@@ -64,8 +64,9 @@ public class InputDate extends InputDateBase {
 				// Get all necessary dates.
 				String datePattern = getDatePattern();
 				Object minimumDate = getMinimumDate();
-				Object timeZoneObject = getTimeZone();
-				TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(timeZoneObject);
+				String timeZoneString = getTimeZone();
+				TimeZone timeZone = TimeZone.getTimeZone(timeZoneString);
+
 				Date minDate = PickDateUtil.getObjectAsDate(minimumDate, datePattern, timeZone);
 				Object maximumDate = getMaximumDate();
 				Date maxDate = PickDateUtil.getObjectAsDate(maximumDate, datePattern, timeZone);
@@ -103,6 +104,8 @@ public class InputDate extends InputDateBase {
 						else {
 							MessageContext messageContext = MessageContext.getInstance();
 							SimpleDateFormat simpleDateFormat = new SimpleDateFormat(datePattern);
+							simpleDateFormat.setTimeZone(timeZone);
+
 							String minDateString = simpleDateFormat.format(minDate);
 							String maxDateString = simpleDateFormat.format(maxDate);
 							Locale locale = PickDateUtil.getObjectAsLocale(getLocale(facesContext));
@@ -151,8 +154,8 @@ public class InputDate extends InputDateBase {
 			Locale locale = PickDateUtil.getObjectAsLocale(objectLocale);
 			dateTimeConverter.setLocale(locale);
 
-			Object objectTimeZone = getTimeZone();
-			TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(objectTimeZone);
+			String timeZoneString = getTimeZone();
+			TimeZone timeZone = TimeZone.getTimeZone(timeZoneString);
 			dateTimeConverter.setTimeZone(timeZone);
 			converter = dateTimeConverter;
 		}
@@ -208,13 +211,7 @@ public class InputDate extends InputDateBase {
 	}
 
 	@Override
-	public Object getTimeZone() {
-		Object timeZone = super.getTimeZone();
-
-		if (timeZone == null) {
-			timeZone = TimeZone.getTimeZone(GREENWICH);
-		}
-
-		return timeZone;
+	public String getTimeZone() {
+		return (String) getStateHelper().eval(InputDatePropertyKeys.timeZone, GREENWICH);
 	}
 }

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDateBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/inputdate/InputDateBase.java
@@ -95,11 +95,11 @@ public abstract class InputDateBase extends InputDateTimeBase implements Styleab
 		getStateHelper().put(InputDatePropertyKeys.panes, panes);
 	}
 
-	public Object getTimeZone() {
-		return (Object) getStateHelper().eval(InputDatePropertyKeys.timeZone, null);
+	public String getTimeZone() {
+		return (String) getStateHelper().eval(InputDatePropertyKeys.timeZone, null);
 	}
 
-	public void setTimeZone(Object timeZone) {
+	public void setTimeZone(String timeZone) {
 		getStateHelper().put(InputDatePropertyKeys.timeZone, timeZone);
 	}
 

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDate.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDate.java
@@ -13,8 +13,6 @@
  */
 package com.liferay.faces.alloy.component.pickdate;
 
-import java.util.TimeZone;
-
 import javax.faces.component.FacesComponent;
 import javax.faces.context.FacesContext;
 
@@ -90,13 +88,7 @@ public class PickDate extends PickDateBase {
 	}
 
 	@Override
-	public Object getTimeZone() {
-		Object timeZone = super.getTimeZone();
-
-		if (timeZone == null) {
-			timeZone = TimeZone.getTimeZone(GREENWICH);
-		}
-
-		return timeZone;
+	public String getTimeZone() {
+		return (String) getStateHelper().eval(PickDatePropertyKeys.timeZone, GREENWICH);
 	}
 }

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateBase.java
@@ -147,11 +147,11 @@ public abstract class PickDateBase extends UIComponentBase implements Styleable,
 		getStateHelper().put(PickDatePropertyKeys.styleClass, styleClass);
 	}
 
-	public Object getTimeZone() {
-		return (Object) getStateHelper().eval(PickDatePropertyKeys.timeZone, null);
+	public String getTimeZone() {
+		return (String) getStateHelper().eval(PickDatePropertyKeys.timeZone, null);
 	}
 
-	public void setTimeZone(Object timeZone) {
+	public void setTimeZone(String timeZone) {
 		getStateHelper().put(PickDatePropertyKeys.timeZone, timeZone);
 	}
 

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRenderer.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateRenderer.java
@@ -159,8 +159,8 @@ public class PickDateRenderer extends PickDateRendererBase {
 		boolean first) throws IOException {
 
 		String datePattern = pickDate.getDatePattern();
-		Object timeZoneObject = pickDate.getTimeZone();
-		TimeZone timeZone = PickDateUtil.getObjectAsTimeZone(timeZoneObject);
+		String timeZoneString = pickDate.getTimeZone();
+		TimeZone timeZone = TimeZone.getTimeZone(timeZoneString);
 		Date date = PickDateUtil.getObjectAsDate(dateObject, datePattern, timeZone);
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(JAVASCRIPT_NEW_DATE_PATTERN);
 		simpleDateFormat.setTimeZone(timeZone);

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateUtil.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/pickdate/PickDateUtil.java
@@ -16,9 +16,7 @@ package com.liferay.faces.alloy.component.pickdate;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -187,35 +185,5 @@ public class PickDateUtil {
 		}
 
 		return locale;
-	}
-
-	public static TimeZone getObjectAsTimeZone(Object timeZoneAsObject) throws FacesException {
-
-		TimeZone timeZone = null;
-
-		if (timeZoneAsObject != null) {
-
-			if (timeZoneAsObject instanceof TimeZone) {
-				timeZone = (TimeZone) timeZoneAsObject;
-			}
-			else if (timeZoneAsObject instanceof String) {
-
-				String timeZoneAsString = (String) timeZoneAsObject;
-
-				if (timeZoneAsString.length() > 0) {
-
-					// Note: The following usage of TimeZone is thread-safe, since only the result of the getTimeZone()
-					// method is utilized.
-					timeZone = TimeZone.getTimeZone(timeZoneAsString);
-				}
-			}
-			else {
-
-				String message = "Unable to convert value to TimeZone.";
-				throw new FacesException(message);
-			}
-		}
-
-		return timeZone;
 	}
 }

--- a/alloy/src/main/resources/META-INF/alloy.taglib.xml
+++ b/alloy/src/main/resources/META-INF/alloy.taglib.xml
@@ -2011,10 +2011,10 @@
 			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
-			<description><![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>.]]></description>
+			<description><![CDATA[The time zone of the component (defaults to "Greenwich").]]></description>
 			<name>timeZone</name>
 			<required>false</required>
-			<type>java.lang.Object</type>
+			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
 			<description><![CDATA[HTML passthrough attribute specifying the title of the element.]]></description>
@@ -4820,10 +4820,10 @@
 			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
-			<description><![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute can be of type <code>java.lang.String</code> or <code>java.util.TimeZone</code>. This attribute is used to determine the time zone of <code>java.text.SimpleDateFormat</code> which is used to parse the <code>minimumDate</code> and <code>maximumDate</code> attributes. If <code>minimumDate</code> and maximumDate</code> are not Strings or are unused, it is not necessary to set this attribute.]]></description>
+			<description><![CDATA[The time zone of the component (defaults to "Greenwich"). This attribute is used to determine the time zone of <code>java.text.SimpleDateFormat</code> which is used to parse the <code>minimumDate</code> and <code>maximumDate</code> attributes. If <code>minimumDate</code> and maximumDate</code> are not Strings or are unused, it is not necessary to set this attribute.]]></description>
 			<name>timeZone</name>
 			<required>false</required>
-			<type>java.lang.Object</type>
+			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
 			<description><![CDATA[Specifies the stack order of the component. The default value is a constant from the Liferay.zIndex JavaScript object.]]></description>


### PR DESCRIPTION
FACES-1895 Develop alloy:pickDate component (Changed timeZone attribute to type java.lang.String to disallow the passing of a TimeZone object directly because TimeZone is not thread safe. Removed unnecessary PickDateUtil.getObjectAsTimeZone() method, instead the thread safe TimeZone.getTimeZone() method can be called in its place.)
FACES-1897 Develop alloy:inputDate component (Changed timeZone attribute to type java.lang.String to disallow the passing of a TimeZone object directly because TimeZone is not thread safe.)
