### PR TITLE
FACES-1898 Develop alloy:dialog, alloy:outputTooltip, and alloy:popover ...

### DIFF
--- a/alloy/components-ext.xml
+++ b/alloy/components-ext.xml
@@ -1001,8 +1001,6 @@
 				</description>
 				<name>autoShow</name>
 				<type>boolean</type>
-				<yui>true</yui>
-				<yuiName>visible</yuiName>
 			</attribute>
 			<attribute>
 				<description>
@@ -1010,8 +1008,6 @@
 				</description>
 				<name>headerText</name>
 				<type>java.lang.String</type>
-				<yui>true</yui>
-				<yuiName>headerContent</yuiName>
 			</attribute>
 			<attribute>
 				<defaultValue>Integer.MIN_VALUE</defaultValue>

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/dialog/DialogRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/dialog/DialogRendererBase.java
@@ -31,12 +31,12 @@ import com.liferay.faces.alloy.component.overlay.OverlayRendererBase;
 public abstract class DialogRendererBase extends OverlayRendererBase {
 
 	// Protected Constants
+	protected static final String AUTO_SHOW = "autoShow";
 	protected static final String CLIENT_KEY = "clientKey";
 	protected static final String DISMISSIBLE = "dismissible";
-	protected static final String HEADER_CONTENT = "headerContent";
+	protected static final String HEADER_TEXT = "headerText";
 	protected static final String HIDE_ICON_RENDERED = "hideIconRendered";
 	protected static final String MODAL = "modal";
-	protected static final String VISIBLE = "visible";
 	protected static final String Z_INDEX = "zIndex";
 
 	// Private Constants
@@ -51,22 +51,6 @@ public abstract class DialogRendererBase extends OverlayRendererBase {
 
 		Dialog dialog = (Dialog) uiComponent;
 		boolean first = true;
-
-		Boolean autoShow = dialog.isAutoShow();
-
-		if (autoShow != null) {
-
-			encodeVisible(responseWriter, dialog, autoShow, first);
-			first = false;
-		}
-
-		String headerText = dialog.getHeaderText();
-
-		if (headerText != null) {
-
-			encodeHeaderContent(responseWriter, dialog, headerText, first);
-			first = false;
-		}
 
 		Boolean modal = dialog.isModal();
 
@@ -95,14 +79,6 @@ public abstract class DialogRendererBase extends OverlayRendererBase {
 	@Override
 	protected String[] getModules() {
 		return MODULES;
-	}
-
-	protected void encodeVisible(ResponseWriter responseWriter, Dialog dialog, Boolean autoShow, boolean first) throws IOException {
-		encodeBoolean(responseWriter, VISIBLE, autoShow, first);
-	}
-
-	protected void encodeHeaderContent(ResponseWriter responseWriter, Dialog dialog, String headerText, boolean first) throws IOException {
-		encodeString(responseWriter, HEADER_CONTENT, headerText, first);
 	}
 
 	protected void encodeModal(ResponseWriter responseWriter, Dialog dialog, Boolean modal, boolean first) throws IOException {

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/outputtooltip/OutputTooltipRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/outputtooltip/OutputTooltipRendererBase.java
@@ -31,12 +31,12 @@ import com.liferay.faces.alloy.component.overlay.OverlayRendererBase;
 public abstract class OutputTooltipRendererBase extends OverlayRendererBase {
 
 	// Protected Constants
+	protected static final String AUTO_SHOW = "autoShow";
 	protected static final String CLIENT_KEY = "clientKey";
-	protected static final String HEADER_CONTENT = "headerContent";
+	protected static final String HEADER_TEXT = "headerText";
 	protected static final String OPACITY = "opacity";
 	protected static final String POSITION = "position";
 	protected static final String TRIGGER = "trigger";
-	protected static final String VISIBLE = "visible";
 	protected static final String Z_INDEX = "zIndex";
 
 	// Private Constants
@@ -52,27 +52,11 @@ public abstract class OutputTooltipRendererBase extends OverlayRendererBase {
 		OutputTooltip outputTooltip = (OutputTooltip) uiComponent;
 		boolean first = true;
 
-		Boolean autoShow = outputTooltip.isAutoShow();
-
-		if (autoShow != null) {
-
-			encodeVisible(responseWriter, outputTooltip, autoShow, first);
-			first = false;
-		}
-
 		String for_ = outputTooltip.getFor();
 
 		if (for_ != null) {
 
 			encodeTrigger(responseWriter, outputTooltip, for_, first);
-			first = false;
-		}
-
-		String headerText = outputTooltip.getHeaderText();
-
-		if (headerText != null) {
-
-			encodeHeaderContent(responseWriter, outputTooltip, headerText, first);
 			first = false;
 		}
 
@@ -113,16 +97,8 @@ public abstract class OutputTooltipRendererBase extends OverlayRendererBase {
 		return MODULES;
 	}
 
-	protected void encodeVisible(ResponseWriter responseWriter, OutputTooltip outputTooltip, Boolean autoShow, boolean first) throws IOException {
-		encodeBoolean(responseWriter, VISIBLE, autoShow, first);
-	}
-
 	protected void encodeTrigger(ResponseWriter responseWriter, OutputTooltip outputTooltip, String for_, boolean first) throws IOException {
 		encodeClientId(responseWriter, TRIGGER, for_, outputTooltip, first);
-	}
-
-	protected void encodeHeaderContent(ResponseWriter responseWriter, OutputTooltip outputTooltip, String headerText, boolean first) throws IOException {
-		encodeString(responseWriter, HEADER_CONTENT, headerText, first);
 	}
 
 	protected void encodeOpacity(ResponseWriter responseWriter, OutputTooltip outputTooltip, String opacity, boolean first) throws IOException {

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/outputtooltip/OutputTooltipResponseWriter.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/outputtooltip/OutputTooltipResponseWriter.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import javax.faces.component.UIComponent;
 import javax.faces.context.ResponseWriter;
 
+import com.liferay.faces.util.component.Styleable;
 import com.liferay.faces.util.lang.StringPool;
 import com.liferay.faces.util.render.DelegationResponseWriterBase;
 
@@ -57,9 +58,9 @@ public class OutputTooltipResponseWriter extends DelegationResponseWriterBase {
 	@Override
 	public void writeAttribute(String name, Object value, String property) throws IOException {
 
-		// Prevent the JSF runtime writing the "id" attribute since the
-		// OutputToolTipRenderer.encodeMarkupBegin(FacesContext, UIComponent) method has already written it.
-		if (!StringPool.ID.equals(name)) {
+		// Prevent the JSF runtime writing the "id", "style", and "class" attributes since the
+		// OutputToolTipRenderer.encodeMarkupBegin(FacesContext, UIComponent) method has already written them.
+		if (!StringPool.ID.equals(name) && !Styleable.STYLE.equals(name) && !Styleable.STYLE_CLASS.equals(name)) {
 			super.writeAttribute(name, value, property);
 		}
 	}

--- a/alloy/src/main/java/com/liferay/faces/alloy/component/popover/PopoverRendererBase.java
+++ b/alloy/src/main/java/com/liferay/faces/alloy/component/popover/PopoverRendererBase.java
@@ -31,13 +31,13 @@ import com.liferay.faces.alloy.component.overlay.OverlayRendererBase;
 public abstract class PopoverRendererBase extends OverlayRendererBase {
 
 	// Protected Constants
+	protected static final String AUTO_SHOW = "autoShow";
 	protected static final String CLIENT_KEY = "clientKey";
 	protected static final String DISMISSIBLE = "dismissible";
 	protected static final String FOR = "for";
-	protected static final String HEADER_CONTENT = "headerContent";
+	protected static final String HEADER_TEXT = "headerText";
 	protected static final String HIDE_ICON_RENDERED = "hideIconRendered";
 	protected static final String POSITION = "position";
-	protected static final String VISIBLE = "visible";
 	protected static final String Z_INDEX = "zIndex";
 
 	// Private Constants
@@ -52,22 +52,6 @@ public abstract class PopoverRendererBase extends OverlayRendererBase {
 
 		Popover popover = (Popover) uiComponent;
 		boolean first = true;
-
-		Boolean autoShow = popover.isAutoShow();
-
-		if (autoShow != null) {
-
-			encodeVisible(responseWriter, popover, autoShow, first);
-			first = false;
-		}
-
-		String headerText = popover.getHeaderText();
-
-		if (headerText != null) {
-
-			encodeHeaderContent(responseWriter, popover, headerText, first);
-			first = false;
-		}
 
 		String position = popover.getPosition();
 
@@ -96,14 +80,6 @@ public abstract class PopoverRendererBase extends OverlayRendererBase {
 	@Override
 	protected String[] getModules() {
 		return MODULES;
-	}
-
-	protected void encodeVisible(ResponseWriter responseWriter, Popover popover, Boolean autoShow, boolean first) throws IOException {
-		encodeBoolean(responseWriter, VISIBLE, autoShow, first);
-	}
-
-	protected void encodeHeaderContent(ResponseWriter responseWriter, Popover popover, String headerText, boolean first) throws IOException {
-		encodeString(responseWriter, HEADER_CONTENT, headerText, first);
 	}
 
 	protected void encodePosition(ResponseWriter responseWriter, Popover popover, String position, boolean first) throws IOException {

--- a/demos/showcase/showcase-webapp/src/main/webapp/component/alloy/popover/general/popover.xhtml
+++ b/demos/showcase/showcase-webapp/src/main/webapp/component/alloy/popover/general/popover.xhtml
@@ -15,7 +15,7 @@
 					</alloy:field>
 					<alloy:commandButton action="#{popoverBackingBean.submit}" onclick="Liferay.component('popover1').hide();"
 						value="#{i18n['submit']}">
-						<f:ajax execute="@form" render="myForm1:outputModel:modelValue" />
+						<f:ajax execute="@form" render="@form" />
 					</alloy:commandButton>
 					<alloy:button onclick="Liferay.component('popover1').hide();" value="#{i18n['cancel']}" />
 				</alloy:popover>
@@ -39,7 +39,7 @@
 					</alloy:field>
 					<alloy:commandButton action="#{popoverBackingBean.submit}" onclick="Liferay.component('popover2').hide();"
 						showCloseIcon="false" value="#{i18n['submit']}">
-						<f:ajax execute="@form" render="myForm2:outputModel:modelValue" />
+						<f:ajax execute="@form" render="@form" />
 					</alloy:commandButton>
 					<alloy:button onclick="Liferay.component('popover2').hide();" value="#{i18n['cancel']}" />
 				</alloy:popover>


### PR DESCRIPTION
...components (Added boundingBox in order to allow developers to specify the dialog for ajax rendering. Since autoShow and headerText attributes are encoded by OverlayRendererBase, removed <yui>true</yui> from autoShow and headerText in components-ext.xml in order to avoid duplicate encoding of the attributes in the child classes as well. In OverlayRendererBase changed javascript to set display style to null rather than 'block' in order to remove the display style after AlloyUI has taken control of the Node.)
