### PR TITLE
Parameter not passed in bridge export-pdf demo

### DIFF
--- a/demos/bridge/jsf2-export-pdf-portlet/src/main/java/com/liferay/faces/demos/resource/CustomerExportResource.java
+++ b/demos/bridge/jsf2-export-pdf-portlet/src/main/java/com/liferay/faces/demos/resource/CustomerExportResource.java
@@ -126,7 +126,7 @@ public class CustomerExportResource extends Resource {
 			String author = "Author Name";
 			htmlFragment = htmlFragment.replaceAll("[\\n]", " ");
 			htmlFragment = htmlFragment.replaceAll("[\\t]", " ");
-			byteArray = PDFUtil.TXT2PDF(headMarkup, headMarkup, pdfTile, description, author);
+			byteArray = PDFUtil.TXT2PDF(htmlFragment, headMarkup, pdfTile, description, author);
 		}
 		catch (Exception e) {
 			logger.error(e.getMessage(), e);


### PR DESCRIPTION
In the CustomerExportResource htmlFragment is never used. Looking at the method call for PDFUtil.TXT2PDF, it appears it was supposed to be the first argument. Sorry if this is a mistake, I just noticed it while trying to figure out how to export resources in a Liferay portlet with JSF.