### PR TITLE
FACES-2097 exclude glassfish jsf-api, and other unnecessary jars 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -853,6 +853,18 @@
 								<groupId>org.icepush</groupId>
 								<artifactId>icepush</artifactId>
 							</exclusion>
+							<exclusion>
+								<groupId>org.glassfish</groupId>
+								<artifactId>javax.faces</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>javax.mail</groupId>
+								<artifactId>mail</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>javax.activation</groupId>
+								<artifactId>javax.activation</artifactId>
+							</exclusion>
 						</exclusions>
 					</dependency>
 				</dependencies>


### PR DESCRIPTION
during packaging with the weblogic profile.